### PR TITLE
Add basic React frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .env
+client/node_modules/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# cuet-delivery-system
-A student-to-student delivery platform for CUET. Includes feed, delivery request posting, one-to-one messaging, and payment after delivery.
+# CUET Delivery System
+
+This project is a simple MERN (MongoDB, Express, React, Node) prototype for a peer-to-peer delivery system for CUET students.
+
+## Backend
+
+The backend is a minimal Express server located at `index.js`. It responds with a welcome message at the root route.
+
+Run it with:
+
+```bash
+node index.js
+```
+
+## Frontend
+
+The `client` directory contains a lightweight React frontend built without a bundler. Open `client/public/index.html` in a browser to try it out. The interface lets students post delivery requests which show up in a list.

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "cuet-delivery-client",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0"
+  }
+}

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CUET Delivery System</title>
+    <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel" src="../src/index.js"></script>
+  </body>
+</html>

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,0 +1,52 @@
+const { useState } = React;
+
+function App() {
+  const [requests, setRequests] = useState([]);
+  const [form, setForm] = useState({ description: '', pickup: '', dropoff: '' });
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    setRequests([...requests, form]);
+    setForm({ description: '', pickup: '', dropoff: '' });
+  };
+
+  return (
+    <div className="App">
+      <h1>CUET Peer to Peer Delivery</h1>
+      <form onSubmit={handleSubmit}>
+        <input
+          name="description"
+          placeholder="Package description"
+          value={form.description}
+          onChange={handleChange}
+        />
+        <input
+          name="pickup"
+          placeholder="Pickup location"
+          value={form.pickup}
+          onChange={handleChange}
+        />
+        <input
+          name="dropoff"
+          placeholder="Drop-off location"
+          value={form.dropoff}
+          onChange={handleChange}
+        />
+        <button type="submit">Request Delivery</button>
+      </form>
+      <ul>
+        {requests.map((req, index) => (
+          <li key={index}>
+            {req.description} from {req.pickup} to {req.dropoff}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/index.js
+++ b/index.js
@@ -1,8 +1,11 @@
 const express = require('express');
+const path = require('path');
 const app = express();
 
+app.use(express.static(path.join(__dirname, 'client/public')));
+
 app.get('/', (req, res) => {
-  res.send('Welcome to CUET Delivery System Backend!');
+  res.sendFile(path.join(__dirname, 'client/public/index.html'));
 });
 
 const PORT = 5000;


### PR DESCRIPTION
## Summary
- serve a static frontend from Express
- build a minimal React interface in `client`
- document how to run both backend and frontend

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68409809fe38832ea22d7f7e75648b0b